### PR TITLE
#161121397 Allow doctors select their specialization area on signup

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,7 +21,8 @@ $(document).on('turbolinks:load', function() {
   routes = {
     '/': '#home',
     '/patients': '#patients',
-    '/doctors': '#doctors'
+    '/doctors': '#doctors',
+    '/specializations': '#specializations'
   };
   Object.keys(routes).forEach(function(key) {
     if (key.length > 1) {

--- a/app/assets/javascripts/specializations.coffee
+++ b/app/assets/javascripts/specializations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/specializations.scss
+++ b/app/assets/stylesheets/specializations.scss
@@ -1,0 +1,66 @@
+// Place all the styles related to the Specializations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+.specialization {
+  
+  #specialization-form {
+    display: flex;
+    flex-wrap: wrap;
+    padding-top: 25vh;
+    width: 500px;
+    height: 330px;
+    margin: auto;
+    
+    #specialization-header {
+      text-align: center;
+      padding-left: 180px;
+    }
+  }
+  
+  .button-group {
+    width: 100%;
+    padding-top: 20px;
+    // margin: auto;
+  }
+}
+
+.specializations-list {
+  margin-left: 180px;
+  #specializations-list-header {
+    text-align: center;
+  }
+  .column {
+    margin-right: -100px;
+  }
+  .specialization-item {
+    max-width: 1000px;
+    width: 400px;
+    height: 100px;
+    margin: 20px 0 20px 80px;
+    padding: 20px 0 20px 0px;
+    z-index: 2;
+    -moz-box-shadow:    1px 1px 1px 1px #ccc;
+    -webkit-box-shadow: 1px 1px 1px 1px #ccc;
+    box-shadow:         1px 1px 1px 1px #ccc;
+    
+    #specialization-name {
+      display: flex;
+      justify-content: flex-start;
+      font-size: 25px;
+      padding: 0 0 0 20px;
+    }
+    #specialization-links {
+      #edit-resource{
+        color: #22BA46;
+      }
+      #delete-resource {
+        color: #DB2728;
+      }
+      padding-right: 10px;
+      margin-top: -20px;
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name address])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: %i[name address specialization_id])
   end
 end

--- a/app/controllers/specializations_controller.rb
+++ b/app/controllers/specializations_controller.rb
@@ -1,0 +1,44 @@
+class SpecializationsController < ApplicationController
+  before_action :find_specialization, only: %i[edit update destroy]
+  def new
+    @specialization = Specialization.new
+  end
+
+  def create
+    @specialization = Specialization.new(specialization_params)
+    if @specialization.save
+      redirect_to root_url
+    else
+      render 'new'
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @specialization.update_attributes(specialization_params)
+      redirect_to root_url
+    else
+      render 'edit'
+    end
+  end
+  
+  def index
+    @specializations = Specialization.all
+  end
+
+  def destroy
+    @specialization.destroy
+    redirect_to root_url
+  end
+
+  private
+
+  def specialization_params
+    params.require(:specialization).permit(:name)
+  end
+
+  def find_specialization
+    @specialization = Specialization.find_by(id: params[:id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,12 +9,37 @@ module ApplicationHelper
   def patient_or_doctor
     if !current_doctor.nil?
       # render stuff
-      content_tag(:a, 'Doctors',
-                  href: doctors_url, class: 'item', id: 'doctors')
+      build_doctor_links(current_doctor)
     elsif !current_patient.nil?
       # render some other stuff
       content_tag(:a, 'Patients',
                   href: patients_url, class: 'item', id: 'patients')
+    end
+  end
+
+  def build_doctor_links(doctor)
+    content = content_tag(:a, 'Doctors',
+                          href: doctors_url, class: 'item', id: 'doctors')
+    return unless doctor.admin?
+    content << build_specialization_links
+  end
+
+  def build_specialization_links
+    content_tag(:div, class: %w[ui dropdown item]) do
+      concat 'Specializations'
+      concat content_tag(:i, '', class: %w[dropdown icon])
+      concat build_specialization_dropdown_items
+    end
+  end
+
+  def build_specialization_dropdown_items
+    content_tag(:div, class: 'menu') do
+      links = content_tag(:a, 'Add Specialization',
+                          href: new_specialization_url, class: 'item',
+                          id: 'specializations')
+      links << content_tag(:a, 'Specializations', href: specializations_url,
+                                                  class: 'item',
+                                                  id: 'specializations')
     end
   end
 end

--- a/app/helpers/specializations_helper.rb
+++ b/app/helpers/specializations_helper.rb
@@ -1,0 +1,2 @@
+module SpecializationsHelper
+end

--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -6,6 +6,7 @@ class Doctor < ApplicationRecord
   include EmailValidation
   has_many :appointments
   has_many :patients, through: :appointments
+  belongs_to :specialization
   validates_presence_of :name, :email
   validates :email, format: { with: EmailValidation::REGEX }
 end

--- a/app/models/specialization.rb
+++ b/app/models/specialization.rb
@@ -1,0 +1,5 @@
+class Specialization < ApplicationRecord
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  has_many :doctors
+end

--- a/app/views/doctors/registrations/new.html.erb
+++ b/app/views/doctors/registrations/new.html.erb
@@ -12,6 +12,11 @@
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
+    
+    <div class="field">
+      <%= f.label :specialization %><br />
+      <%= f.collection_select(:specialization_id, Specialization.all, :id, :name, {}, { class: "ui dropdown" }) %>
+    </div>
 
     <div class="field">
       <%= f.label :password %>

--- a/app/views/specializations/_form.html.erb
+++ b/app/views/specializations/_form.html.erb
@@ -1,0 +1,15 @@
+<div class="ui container raised segment">
+  <%= form_for @specialization, html: {class: "ui form"} do |f| %>
+  
+   <div class="input-field">
+     <div class="field">
+       <%= f.label :name %>
+       <%= f.text_field :name %>
+     </div>
+   </div>
+    
+    <div class="button-group">
+      <%= f.submit "Submit", class: "ui button button-centered" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/specializations/_specialization.html.erb
+++ b/app/views/specializations/_specialization.html.erb
@@ -1,0 +1,11 @@
+<div class="column">
+  <div class="specialization-item">
+    <div id="specialization-name"><%= specialization.name %></div>
+    <div id="specialization-links" class="ui right floated">
+      <%= link_to semantic_icon("edit icon"), edit_specialization_path(specialization), id: "edit-resource"%>
+      <%= link_to semantic_icon("trash icon"), specialization, method: :delete,
+                                     data: {confirm: "You sure?"},
+                                     id: "delete-resource" %> 
+    </div>
+  </div>
+</div>

--- a/app/views/specializations/edit.html.erb
+++ b/app/views/specializations/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="specialization">  
+  <div id="specialization-form">
+    <h2 id="specialization-header">
+      Edit <%= @specialization.name %>
+    </h2>
+    <%= render 'form' %>
+  </div>
+  
+</div>

--- a/app/views/specializations/index.html.erb
+++ b/app/views/specializations/index.html.erb
@@ -1,0 +1,10 @@
+<div class="specializations-list">
+  <h2 id="specializations-list-header">
+    All specializations
+  </h2>
+  <div class="ui stackable three column grid">
+    <div class="row">
+      <%= render @specializations %>
+    </div>
+  </div>
+</div>

--- a/app/views/specializations/new.html.erb
+++ b/app/views/specializations/new.html.erb
@@ -1,0 +1,9 @@
+<div class="specialization">  
+  <div id="specialization-form">
+    <h2 id="specialization-header">
+      Add a new specialization
+    </h2>
+    <%= render 'form' %>
+  </div>
+  
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # get 'doctors/edit'
   # get 'doctors/show'
 
-  resources :appointments
+  resources :appointments, :specializations
   resources :patients do
     get 'appointments', on: :member
   end

--- a/db/migrate/20181010150458_create_specializations.rb
+++ b/db/migrate/20181010150458_create_specializations.rb
@@ -1,0 +1,9 @@
+class CreateSpecializations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :specializations do |t|
+      t.string :name, default: '', null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181010154910_add_specialization_to_doctors.rb
+++ b/db/migrate/20181010154910_add_specialization_to_doctors.rb
@@ -1,0 +1,5 @@
+class AddSpecializationToDoctors < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :doctors, :specialization, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_13_171204) do
+ActiveRecord::Schema.define(version: 2018_10_10_154910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,9 @@ ActiveRecord::Schema.define(version: 2018_09_13_171204) do
     t.bigint "patient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "patient_notes", default: "", null: false
+    t.text "doctor_notes", default: "", null: false
+    t.boolean "confirmed", default: false, null: false
     t.index ["doctor_id"], name: "index_appointments_on_doctor_id"
     t.index ["patient_id"], name: "index_appointments_on_patient_id"
   end
@@ -34,8 +37,12 @@ ActiveRecord::Schema.define(version: 2018_09_13_171204) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.boolean "admin", default: false
+    t.string "specialization", default: ""
+    t.bigint "specialization_id"
     t.index ["email"], name: "index_doctors_on_email", unique: true
     t.index ["reset_password_token"], name: "index_doctors_on_reset_password_token", unique: true
+    t.index ["specialization_id"], name: "index_doctors_on_specialization_id"
   end
 
   create_table "patients", force: :cascade do |t|
@@ -52,6 +59,13 @@ ActiveRecord::Schema.define(version: 2018_09_13_171204) do
     t.index ["reset_password_token"], name: "index_patients_on_reset_password_token", unique: true
   end
 
+  create_table "specializations", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "appointments", "doctors"
   add_foreign_key "appointments", "patients"
+  add_foreign_key "doctors", "specializations"
 end

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AppointmentsController, type: :request do
-  let!(:doctor) { create :doctor }
+  let!(:doctor) { create :doctor_with_specialization }
   let!(:patient) { create :patient }
   let!(:params) do
     { appointment: {

--- a/spec/controllers/doctors_controller_spec.rb
+++ b/spec/controllers/doctors_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DoctorsController, type: :request do
-  let!(:doctor) { create :doctor }
+  let!(:doctor) { create :doctor_with_specialization }
   let!(:patient) { create :patient }
 
   describe 'GET #edit' do

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PatientsController, type: :request do
-  let!(:doctor) { create :doctor }
+  let!(:doctor) { create :doctor_with_specialization }
   let!(:patient) { create :patient }
 
   describe 'GET #edit' do

--- a/spec/controllers/specializations_controller_spec.rb
+++ b/spec/controllers/specializations_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe SpecializationsController, type: :request do
+  let!(:test_specialization) { create :specialization }
+  let!(:specialization) do
+    { specialization: attributes_for(:specialization) }
+  end
+  describe 'GET #new' do
+    it 'renders the new template' do
+      get new_specialization_path
+      expect(response).to render_template :new
+    end
+  end
+
+  describe 'POST #create' do
+    it 'saves a new specialization and redirect to the home page' do
+      post specializations_path, params: specialization
+      expect(response).to redirect_to :root
+      follow_redirect!
+    end
+
+    it 'should render the new template if something went wrong' do
+      specialization[:specialization][:name] = nil
+      post specializations_path, params: specialization
+      expect(response).to render_template :new
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'renders the edit template' do
+      get edit_specialization_path(test_specialization.id)
+      expect(response).to render_template :edit
+    end
+  end
+
+  describe 'PUT #update' do
+    it 'should redirect to the home page if the update is successful' do
+      put specialization_path(test_specialization.id), params: specialization
+      expect(response).to redirect_to :root
+      follow_redirect!
+    end
+
+    it 'should render the edit template if something went wrong' do
+      specialization[:specialization][:name] = nil
+      put specialization_path(test_specialization.id), params: specialization
+      expect(response).to render_template :edit
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'should delete the specialization from the database' do
+      expect do
+        delete specialization_path(test_specialization.id)
+      end.to change(Specialization, :count).by(-1)
+    end
+
+    it 'redirects to the home page if a delete attempt is successful' do
+      delete specialization_path(test_specialization.id)
+      expect(response).to redirect_to :root
+      follow_redirect!
+    end
+  end
+end

--- a/spec/factories/doctor.rb
+++ b/spec/factories/doctor.rb
@@ -3,5 +3,11 @@ FactoryBot.define do
     name { Faker::OnePiece.character }
     email { "#{Faker::Name.first_name}@hospital.com" }
     password { 'password' }
+
+    factory :doctor_with_specialization do
+      before(:create) do |doctor|
+        doctor.specialization_id = create(:specialization).id
+      end
+    end
   end
 end

--- a/spec/factories/specializations.rb
+++ b/spec/factories/specializations.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :specialization do
+    name { Faker::OnePiece.character }
+
+    factory :specialization_with_doctor do
+      after(:create) do |specialization|
+        create(:doctor, specialization_id: specialization.id)
+      end
+    end
+  end
+end

--- a/spec/helpers/specializations_helper_spec.rb
+++ b/spec/helpers/specializations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SpecializationsHelper. For example:
+#
+# describe SpecializationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SpecializationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/specialization_spec.rb
+++ b/spec/models/specialization_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Specialization, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_uniqueness_of(:name).case_insensitive }
+end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,7 +2,16 @@ module ControllerMacros
   def login_doctor
     before(:each) do
       @request.env['devise.mapping'] = Devise.mappings[:doctor]
-      sign_in FactoryBot.create(:doctor) # Using factory bot as an example
+      sign_in FactoryBot.create(:doctor_with_specialization)
+    end
+  end
+
+  def login_admin
+    before(:each) do
+      @request.env['devise.mapping'] = Devise.mappings[:doctor]
+      specialization = FactoryBot.create(:specialization_with_doctor)
+      specialization.doctors.first.update_attributes(admin: true)
+      sign_in specialization.doctors.first
     end
   end
 

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe 'layouts/_header.html.erb', type: :view do
         render template: 'layouts/_header.html.erb'
 
         expect(rendered).to match 'doctors'
+        expect(rendered).to_not match 'Specializations'
+      end
+    end
+  end
+
+  describe 'admins logged in' do
+    login_admin
+    context 'when the doctor is an admin' do
+      it 'renders admin-only links' do
+        render template: 'layouts/_header.html.erb'
+        expect(rendered).to match 'Specializations'
       end
     end
   end

--- a/spec/views/specializations/edit.html.erb_spec.rb
+++ b/spec/views/specializations/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "specializations/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/specializations/new.html.erb_spec.rb
+++ b/spec/views/specializations/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "specializations/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#### What does this PR do?
Allow doctors to select their specialization area when signing up
#### Description of Task to be completed?
* Allow admins add/edit specialization areas
* Allow doctors select their specialization area when signing up
#### How should this be manually tested?
* Start up your server
* Go to the signup page for doctors
* You should see a drop-down that allows you to select a specialization
#### What are the relevant pivotal tracker stories?
[#161121397](https://www.pivotaltracker.com/story/show/161121397)
#### Any background context you want to add?
N/A
#### Screenshots
![screen shot 2018-10-11 at 6 05 15 pm](https://user-images.githubusercontent.com/11176000/46821357-562b8200-cd80-11e8-8928-9812826922ff.png)
![screen shot 2018-10-11 at 6 05 29 pm](https://user-images.githubusercontent.com/11176000/46821360-562b8200-cd80-11e8-87b7-98dacff0281f.png)
