### PR TITLE
#161817215 Only allow future appointment dates

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -13,6 +13,7 @@ class AppointmentsController < ApplicationController
 
   def create
     @appointment = current_patient.appointments.build(appointment_params)
+    # binding.pry
     if @appointment.save
       AppointmentMailer.with(appointment: @appointment)
                        .new_appointment.deliver_later
@@ -30,7 +31,7 @@ class AppointmentsController < ApplicationController
 
   def update
     @appointment.status = 'confirmed'
-    if @appointment.save
+    if @appointment.update_attributes(appointment_params)
       AppointmentMailer.with(appointment: @appointment)
                        .confirm_appointment.deliver_later
       redirect_to pending_appointments_url

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -13,6 +13,7 @@ class Appointment < ApplicationRecord
   belongs_to :specialization
 
   validates_presence_of :appointment_date
+  validate :date_in_future
 
   # this method sets a default doctor_id before saving an appointment
   # the doctor_id doesn't allow null values so an actual value has to be set
@@ -21,5 +22,12 @@ class Appointment < ApplicationRecord
   def set_default_doctor_id
     return unless doctor_id.nil?
     self.doctor_id = Doctor.find_by(admin: true).id || 0
+  end
+
+  def date_in_future
+    return if appointment_date && appointment_date > Date.today
+    errors.add(
+      :date_in_future, 'Date must be at least a day after current date'
+    )
   end
 end

--- a/app/views/appointments/_form.html.erb
+++ b/app/views/appointments/_form.html.erb
@@ -11,7 +11,7 @@
       <div class="input-field">
         <div class="field">
           <%= f.label :appointment_date%>
-          <%= f.date_field :appointment_date %>
+          <%= f.date_field :appointment_date, selected: Time.now + 1.day, min: Time.now %>
         </div>
       </div>
       

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,8 +27,8 @@ ActiveRecord::Schema.define(version: 2018_11_05_153453) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.bigint "specialization_id"
     t.boolean "admin", default: false
+    t.bigint "specialization_id"
     t.index ["email"], name: "index_doctors_on_email", unique: true
     t.index ["reset_password_token"], name: "index_doctors_on_reset_password_token", unique: true
     t.index ["specialization_id"], name: "index_doctors_on_specialization_id"

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AppointmentsController, type: :request do
   let!(:doctor) { create :doctor_with_specialization, :admin }
   let!(:patient) { create :patient }
   let!(:specialization) { create :specialization }
-  let!(:params) do
+  let!(:legit_params) do
     { appointment: {
       appointment_date: Time.now,
       doctor_id: doctor.id,
@@ -16,7 +16,8 @@ RSpec.describe AppointmentsController, type: :request do
     { appointment: {
       doctor_id: 'a',
       patient_id: 'a',
-      specialization_id: 'a'
+      specialization_id: 'a',
+      appointment_date: 'a'
     } }
   end
   describe 'GET #new' do
@@ -29,7 +30,7 @@ RSpec.describe AppointmentsController, type: :request do
   describe 'POST #create' do
     it 'should redirect to the home page if an appointment is saved successfully' do
       sign_in patient
-      post appointments_path, params: params
+      post appointments_path, params: legit_params
       expect(response).to redirect_to :root
       follow_redirect!
     end
@@ -54,8 +55,8 @@ RSpec.describe AppointmentsController, type: :request do
     describe 'PUT #update' do
       it 'should redirect to the home page if update is successful' do
         sign_in patient
-        put appointment_path(appointment.id), params: params
-        expect(response).to redirect_to :root
+        put appointment_path(appointment.id), params: legit_params
+        expect(response).to redirect_to :pending_appointments
         follow_redirect!
       end
       it 'should render the edit template if the edit isn\'t successful' do

--- a/spec/factories/appointment.rb
+++ b/spec/factories/appointment.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :appointment do
-    appointment_date { Time.now }
+    appointment_date { Time.now + 1.day }
     doctor_id { create(:doctor_with_specialization).id }
     patient_id { create(:patient).id }
     specialization_id { create(:specialization).id }

--- a/spec/factories/specializations.rb
+++ b/spec/factories/specializations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :specialization do
-    name { Faker::OnePiece.character }
+    name { Faker::Name.first_name }
 
     factory :specialization_with_doctor do
       after(:create) do |specialization|

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe Appointment, type: :model do
     it { should validate_presence_of(:appointment_date) }
   end
 
+  describe 'only accept date at least one day from current date' do
+    let!(:appointment) { create :appointment }
+    context 'when the appointment has a date in the future' do
+      it 'should be valid' do
+        expect(appointment).to be_valid
+      end
+    end
+    context 'when the appointment has a date in the past' do
+      it 'should be not valid' do
+        appointment.appointment_date = 1.day.ago
+        expect(appointment).to_not be_valid
+      end
+    end
+    context 'when the appointment\'s date is the same as the current date' do
+      it 'should be not valid' do
+        appointment.appointment_date = Date.today
+        expect(appointment).to_not be_valid
+      end
+    end
+  end
+
   describe 'associations' do
     it { should belong_to(:patient) }
     it { should belong_to(:doctor) }


### PR DESCRIPTION
#### What does this PR do?
Only save appointments with future appointment dates
#### Description of Task to be completed?
* Allow patients to only enter an appointment date at least one day from whatever date they are making the appointment on
#### How should this be manually tested?
* Log in as a patient and attempt to make an appointment
* You should not be able to select the current date or any date before it
#### What are the relevant pivotal tracker stories?
[#161817215](https://www.pivotaltracker.com/story/show/161817215)
#### Any background context you want to add?
N/A
#### Screenshots
<img width="226" alt="screen shot 2018-11-09 at 5 19 36 pm" src="https://user-images.githubusercontent.com/11176000/48274481-b24afa00-e443-11e8-9fee-a1f96d36dd80.png">
