### PR TITLE
 Show specializations with at least one doctor

### DIFF
--- a/app/helpers/appointments_helper.rb
+++ b/app/helpers/appointments_helper.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
+# Helpers for Appointments controllers and views
 module AppointmentsHelper
   def retrieve_specializations
-    Specialization.all.order(name: :asc)
+    Specialization.joins(:doctors).order(name: :asc).uniq
   end
 
   def get_doctors_by_specialization(specialization_id)

--- a/spec/views/appointments/new.html.erb_spec.rb
+++ b/spec/views/appointments/new.html.erb_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe "appointments/new.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'appointments/new.html.erb', type: :view do
+  let!(:specializations) { create_list :specialization_with_doctor, 3 }
+  let!(:specialization) { create :specialization }
+  let!(:appointment) { create :appointment }
+  before do
+    instance_variable_set(:@appointment, Appointment.first)
+  end
+  context 'when user wants to make an appointment' do
+    it 'should only show specializations with doctors associated with them' do
+      render template: 'appointments/new.html.erb'
+
+      expect(rendered).to match specializations.first.name
+      expect(rendered).to match specializations.second.name
+      expect(rendered).to match specializations.third.name
+
+      expect(rendered).to_not match specialization.name
+    end
+  end
 end


### PR DESCRIPTION
#### What does this PR do?
Show specializations with at least one doctor when booking appointments
#### Description of Task to be completed?
* Modify helper that retrieves specializations to only retrieve those that have associated doctors
#### How should this be manually tested?
* Log in as a patient
* Go to the new appointments page
* You should only see specializations with associated doctors
#### What are the relevant pivotal tracker stories?
[#161817233](https://www.pivotaltracker.com/story/show/161817233)
#### Any background context you want to add?
N/A
#### Screenshots
N/A