### PR TITLE
#161816932 Prevent a patient from seeing other patients

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,19 +11,19 @@ module ApplicationHelper
       # render stuff
       build_doctor_links(current_doctor)
     elsif !current_patient.nil?
-      content = content_tag(:a, 'Patients',
-                            href: patients_url, class: 'item', id: 'patients')
-      content << content_tag(:a, 'Make an appointment',
-                             href: new_appointment_path,
-                             class: 'item', id: 'appointments')
+      content_tag(:a, 'Make an appointment',
+                  href: new_appointment_path,
+                  class: 'item', id: 'appointments')
     end
   end
 
   def build_doctor_links(doctor)
-    content = content_tag(:a, 'Doctors',
-                          href: doctors_url, class: 'item', id: 'doctors')
-    content << build_appointments_links
+    content = build_appointments_links
     return content unless doctor.admin?
+    content << content_tag(:a, 'Doctors',
+                           href: doctors_url, class: 'item', id: 'doctors')
+    content << content_tag(:a, 'Patients',
+                           href: patients_url, class: 'item', id: 'patients')
     content << build_specialization_links
   end
 

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'layouts/_header.html.erb', type: :view do
       it 'renders admin-only links' do
         render template: 'layouts/_header.html.erb'
         expect(rendered).to match 'Specializations'
+        expect(rendered).to match 'Patients'
       end
     end
   end
@@ -31,8 +32,8 @@ RSpec.describe 'layouts/_header.html.erb', type: :view do
     context 'when a patient is logged in' do
       it 'only shows the links patients can see' do
         render template: 'layouts/_header.html.erb'
-        expect(rendered).to match 'patients'
         expect(rendered).to match 'Make an appointment'
+        expect(rendered).to_not match 'Patients'
       end
     end
   end


### PR DESCRIPTION
#### What does this PR do?
Removes the link to view all patients from the navbar when a patient is logged in
#### Description of Task to be completed?
* Removes the link to view all patients from the navbar when a patient is logged in
* Only show the link to view all patients when an admin is signed in
#### How should this be manually tested?
* Log in as a patient
* You should not see a `Patients` link in the navbar
#### What are the relevant pivotal tracker stories?
[#161816932](https://www.pivotaltracker.com/story/show/161816932)
#### Any background context you want to add?
Done for security reasons, so patients don't have access to other patients' info
#### Screenshots
N/A