### PR TITLE
#161846526 Restrict appointment booking fequency

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -13,6 +13,13 @@ class Appointment < ApplicationRecord
   belongs_to :specialization
 
   validates_presence_of :appointment_date
+
+  # validate using a scope so users can't book more than one appointment
+  # with the same specialization in a day
+  validates :appointment_date, uniqueness: {
+    scope: :specialization_id,
+    message: 'You can only book one appointment with a specialization per day'
+  }
   validate :date_in_future
 
   # this method sets a default doctor_id before saving an appointment

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,9 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  let!(:doctor) { create :doctor_with_specialization, admin: true }
   describe 'values are present' do
-    let!(:doctor) { create :doctor_with_specialization, admin: true }
     it { should validate_presence_of(:appointment_date) }
+  end
+
+  describe 'appointment date uniqueness scope with specialization_id' do
+    subject { FactoryBot.build(:appointment) }
+    message = 'You can only book one appointment with a specialization per day'
+    it {
+      should validate_uniqueness_of(:appointment_date)
+        .scoped_to(:specialization_id)
+        .with_message(message)
+    }
   end
 
   describe 'only accept date at least one day from current date' do


### PR DESCRIPTION
- only allow a patient book an appointment per day with the same specialization

why: to prevent people from spamming the system

[Finishes ]

#### What does this PR do?
Only allows patients to book one appointment per day with a particular specialization
#### Description of Task to be completed?
* Only allows patients to book one appointment per day with a particular specialization
* Add a scope on an appointment's `appointment_date` using the `specialization_id`
#### How should this be manually tested?
* Log in as a patient
* Book an appointment
* Try to book an appointment with the same details as the first one
* You should get a message telling you that you can't create more than one appointment with the same specialization per day
#### What are the relevant pivotal tracker stories?
[#161846526](https://www.pivotaltracker.com/story/show/161846526)
#### Any background context you want to add?
N/A
#### Screenshots
<img width="536" alt="screen shot 2018-11-13 at 11 30 42 am" src="https://user-images.githubusercontent.com/11176000/48407690-b9ba1e00-e737-11e8-95da-63e198e38fb1.png">
