### PR TITLE
#161816961 Redirect to specializations page after adding a new one

### DIFF
--- a/app/assets/javascripts/specializations.coffee
+++ b/app/assets/javascripts/specializations.coffee
@@ -1,3 +1,9 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+$(document).on 'turbolinks:load', ->
+  $('#specialization-pagination-links').bind 'click', (event) ->
+    window.scrollTo 0,0
+    $('.ui.stackable.three.column.grid').html '<div class="ui segment"><p></p><div class="ui active inverted dimmer centered inline"><div class="ui massive loader"></div></div></div>'
+    return
+  return

--- a/app/assets/stylesheets/specializations.scss
+++ b/app/assets/stylesheets/specializations.scss
@@ -73,4 +73,30 @@
       justify-content: flex-end;
     }
   }
+
+  // Come back to this later
+  // .ui.stackable.three.column.grid {
+  //   display: flex;
+  //   justify-content: center;
+  //   align-items: center;
+  //   .ui.active.inverted.dimmer.centered.inline {
+  //   display: flex;
+  //   justify-content: center;
+  //   align-items: center;
+  // }
+  // }
+}
+
+#specialization-pagination-links {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: px-to-rem(100px) 0 px-to-rem(30px) 0;
+
+  .pagination.ui.menu.pagination {
+    .item.active {
+      background: #22BA46;
+      color: white;
+    }
+  }
 }

--- a/app/controllers/specializations_controller.rb
+++ b/app/controllers/specializations_controller.rb
@@ -24,7 +24,7 @@ class SpecializationsController < ApplicationController
   end
 
   def index
-    @specializations = Specialization.all
+    @specializations = Specialization.all.paginate(page: params[:page], per_page: 6)
   end
 
   def destroy

--- a/app/controllers/specializations_controller.rb
+++ b/app/controllers/specializations_controller.rb
@@ -7,7 +7,7 @@ class SpecializationsController < ApplicationController
   def create
     @specialization = Specialization.new(specialization_params)
     if @specialization.save
-      redirect_to root_url
+      redirect_to specializations_url
     else
       render 'new'
     end
@@ -17,12 +17,12 @@ class SpecializationsController < ApplicationController
 
   def update
     if @specialization.update_attributes(specialization_params)
-      redirect_to root_url
+      redirect_to specializations_url
     else
       render 'edit'
     end
   end
-  
+
   def index
     @specializations = Specialization.all
   end

--- a/app/views/specializations/_form.html.erb
+++ b/app/views/specializations/_form.html.erb
@@ -1,5 +1,12 @@
 <div class="ui container raised segment">
   <%= form_for @specialization, html: {class: "ui form"} do |f| %>
+    <% if @specialization && @specialization.errors.any? %>
+      <ul>
+      <% @specialization.errors.full_messages.each do |error_message| %>
+        <li><%= error_message %></li>
+      <% end %>
+      </ul>
+    <% end %>
   
    <div class="input-field">
      <div class="field">

--- a/app/views/specializations/index.html.erb
+++ b/app/views/specializations/index.html.erb
@@ -8,3 +8,6 @@
     </div>
   </div>
 </div>
+<div id="specialization-pagination-links">
+  <%= will_paginate @specializations, renderer: WillPaginateSemanticUi::ActionView::Renderer %>    
+</div> 

--- a/spec/controllers/specializations_controller_spec.rb
+++ b/spec/controllers/specializations_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SpecializationsController, type: :request do
   describe 'POST #create' do
     it 'saves a new specialization and redirect to the home page' do
       post specializations_path, params: specialization
-      expect(response).to redirect_to :root
+      expect(response).to redirect_to :specializations
       follow_redirect!
     end
 
@@ -36,7 +36,7 @@ RSpec.describe SpecializationsController, type: :request do
   describe 'PUT #update' do
     it 'should redirect to the home page if the update is successful' do
       put specialization_path(test_specialization.id), params: specialization
-      expect(response).to redirect_to :root
+      expect(response).to redirect_to :specializations
       follow_redirect!
     end
 


### PR DESCRIPTION
#### What does this PR do?
Redirect to specializations page after adding a new one
#### Description of Task to be completed?
* Redirect to specializations page after adding a new one
* Add pagination for specializations page
#### How should this be manually tested?
* Log in as an admin
* Add a new specialization
* If it's successful, it should redirect you to the specializations page
#### What are the relevant pivotal tracker stories?
[#161816961](https://www.pivotaltracker.com/story/show/161816961)
#### Any background context you want to add?
N/A
#### Screenshots
N/A