### PR TITLE
Ft allow admin add and delete doctors 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /storage/*
 
 /node_modules
+/.idea
 /yarn-error.log
 
 /public/assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)

--- a/app/assets/stylesheets/doctors.scss
+++ b/app/assets/stylesheets/doctors.scss
@@ -1,10 +1,11 @@
 // Place all the styles related to the Doctors controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-
-.centered{
+@import "base";
+#new-doctor{
   width: 50%;
   margin: auto;
+  padding-top: 5vh;
   .button-group {
     padding-top: 20px;
     .button-centered {
@@ -15,8 +16,39 @@
     font-size: 15px;
     margin-top: 10px;
   }
+  #new-doctor-heading {
+    text-align: center;
+    padding-bottom: px-to-rem(10px);
+  }
 }
 
 .doctor-details {
   padding-top: 10vh;
 }
+
+.update-password {
+  height: 100%;
+  margin: 0;
+  #edit-doctor {
+    height: 100%;
+    margin-top: px-to-rem(-30px);
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    // margin: auto;
+    #edit-doctor-form {
+      width: 30%;
+      padding-top: 2vh;
+
+      .button-group {
+        padding-top: 20px;
+        .button-centered {
+          width: 100%;
+        }
+      }
+    }
+    // font-size: px-to-rem(50px);
+  }
+}
+

--- a/app/controllers/doctors_controller.rb
+++ b/app/controllers/doctors_controller.rb
@@ -1,4 +1,5 @@
 class DoctorsController < ApplicationController
+  include DoctorsHelper
   before_action :find_doctor,
                 only: %i[edit update_password show destroy appointments]
   before_action :redirect_unless_admin, only: :destroy
@@ -35,8 +36,10 @@ class DoctorsController < ApplicationController
   def show; end
 
   def destroy
+    # binding.pry
+    reassign_appointments(@doctor) if doctor_has_appointments?(@doctor)
     @doctor.destroy
-    redirect_to root_url
+    redirect_to root_path
   end
 
   def appointments
@@ -53,7 +56,7 @@ class DoctorsController < ApplicationController
   end
 
   def find_doctor
-    @doctor = current_doctor
+    @doctor = Doctor.find_by(id: params[:id]) || current_doctor
     # @doctor = Doctor.find_by(id: params[:id])
   end
 

--- a/app/controllers/doctors_controller.rb
+++ b/app/controllers/doctors_controller.rb
@@ -1,21 +1,27 @@
 class DoctorsController < ApplicationController
-  before_action :find_doctor, only: %i[edit update show destroy appointments]
-  # def new
-  #   @doctor = Doctor.new
-  # end
-  # 
-  # def create
-  #   binding.pry
-  #   @doctor = Doctor.new(doctor_params)
-  #   if @doctor.save
-  #     redirect_to root_url
-  #   end
-  # end
+  before_action :find_doctor,
+                only: %i[edit update_password show destroy appointments]
+  before_action :redirect_unless_admin, only: :destroy
+  def new
+    @doctor = Doctor.new
+  end
+
+  def create
+    @doctor = Doctor.new(doctor_params)
+    if @doctor.save
+      DoctorMailer.with(doctor: @doctor).update_password.deliver_later
+      redirect_to doctors_url
+    else
+      render 'new'
+    end
+  end
 
   def edit; end
 
-  def update
-    if @doctor.update_attributes(doctor_params)
+  def update_password
+    if @doctor.update_with_password(doctor_params)
+      # Sign in the user by passing validation in case their password changed
+      bypass_sign_in @doctor, scope: :doctor
       redirect_to root_url
     else
       render 'edit'
@@ -38,11 +44,20 @@ class DoctorsController < ApplicationController
   end
 
   private
+
   def doctor_params
-    params.require(:doctor).permit(:name, :email)
+    params.require(:doctor).permit(
+      :name, :email, :specialization_id, :password, :password_confirmation,
+      :current_password
+    )
   end
 
   def find_doctor
-    @doctor = Doctor.find_by(id: params[:id])
+    @doctor = current_doctor
+    # @doctor = Doctor.find_by(id: params[:id])
+  end
+
+  def redirect_unless_admin
+    redirect_to root_url unless current_doctor.admin
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,11 +20,30 @@ module ApplicationHelper
   def build_doctor_links(doctor)
     content = build_appointments_links
     return content unless doctor.admin?
-    content << content_tag(:a, 'Doctors',
-                           href: doctors_url, class: 'item', id: 'doctors')
+    content << build_doctor_dropdown
+    # content << content_tag(:a, 'Doctors',
+    #                        href: doctors_url, class: 'item', id: 'doctors')
     content << content_tag(:a, 'Patients',
                            href: patients_url, class: 'item', id: 'patients')
     content << build_specialization_links
+  end
+
+  def build_doctor_dropdown
+    content_tag(:div, class: %w[ui dropdown item]) do
+      concat 'Doctors'
+      concat content_tag(:i, '', class: %w[dropdown icon])
+      concat build_doctor_dropdown_items
+    end
+  end
+
+  def build_doctor_dropdown_items
+    content_tag(:div, class: 'menu') do
+      links = content_tag(:a, 'Add a new doctor',
+                          href: new_doctor_path, class: 'item',
+                          id: 'add-doctor')
+      links << content_tag(:a, 'View Doctors',
+                           href: doctors_url, class: 'item', id: 'doctors')
+    end
   end
 
   def build_specialization_links

--- a/app/helpers/doctors_helper.rb
+++ b/app/helpers/doctors_helper.rb
@@ -1,2 +1,28 @@
+# frozen_string_literal: true
+
+# Helper methods for the DoctorsController and Doctors views
 module DoctorsHelper
+  def doctor_has_appointments?(doctor)
+    return false if doctor.appointments.count.zero?
+    true
+  end
+
+  def reassign_appointments(doctor)
+    appointments = doctor.appointments
+    admin = Doctor.fetch_admin
+
+    appointments.each do |appointment|
+      patient = appointment.patient
+      # appointment.status = 'pending'
+      # appointment.doctor_id = admin.id
+      # appointment.save!
+      appointment.update_attributes(status: 'pending', doctor_id: admin.id)
+
+      # mailers
+      if appointment.confirmed?
+        AppointmentMailer
+          .with(patient: patient).change_of_doctor.deliver_later
+      end
+    end
+  end
 end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,6 +1,8 @@
 class AppointmentMailer < ApplicationMailer
   default from: 'hospital@kachirocks.com'
-  before_action :retrieve_admins, only: %i(new_appointment confirm_appointment)
+  before_action :retrieve_admins, only: %i[
+    new_appointment confirm_appointment change_of_doctor
+  ]
 
   def new_appointment
     @appointment = params[:appointment]
@@ -22,6 +24,11 @@ class AppointmentMailer < ApplicationMailer
     @patient = @appointment.patient.name
     @doctor = @appointment.doctor.name
     mail(to: @patient, subject: 'Your appointment has been declined')
+  end
+
+  def change_of_doctor
+    @patient = params[:patient]
+    mail(to: @patient.email, bcc: @doctors, subject: 'Change of doctor')
   end
 
   def retrieve_admins

--- a/app/mailers/doctor_mailer.rb
+++ b/app/mailers/doctor_mailer.rb
@@ -1,0 +1,8 @@
+class DoctorMailer < ApplicationMailer
+  default from: 'hospital@kachirocks.com'
+
+  def update_password
+    @doctor = params[:doctor]
+    mail(to: @doctor.email, subject: 'Update your password')
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -20,7 +20,8 @@ class Appointment < ApplicationRecord
     scope: :specialization_id,
     message: 'You can only book one appointment with a specialization per day'
   }
-  validate :date_in_future
+  # only run validation when creating new records
+  validate :date_in_future, on: :create
 
   # this method sets a default doctor_id before saving an appointment
   # the doctor_id doesn't allow null values so an actual value has to be set

--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -9,4 +9,7 @@ class Doctor < ApplicationRecord
   belongs_to :specialization
   validates_presence_of :name, :email
   validates :email, format: { with: EmailValidation::REGEX }
+  def self.fetch_admin
+    Doctor.where(admin: true).first
+  end
 end

--- a/app/views/appointment_mailer/change_of_doctor.html.erb
+++ b/app/views/appointment_mailer/change_of_doctor.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>You're getting a new doctor</h1>
+    <p>
+      Hi <span style="font-weight: bold; font-style: italic; font-size: 18px;"><%= @patient.name %> </span>,  due to some unforeseen circumstances, you'll be getting assigned to a new doctor. <br />
+      We'll be sending a mail across soon with your new appointment details. We apologize for any inconvenience
+      <!-- Add a link to the page for managing an appointment here -->
+    </p>
+  </body>
+</html>

--- a/app/views/doctor_mailer/update_password.html.erb
+++ b/app/views/doctor_mailer/update_password.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hey <%= @doctor.name %>! Welcome to Kachi's Hospital</h1>
+    <p>
+       Welcome to Kachi's Hospital. Please complete your registration to start attending to patients by
+       clicking <%= link_to "here", edit_doctor_url(@doctor) %>
+      <!-- Add a link to the page for managing an appointment here -->
+    </p>
+  </body>
+</html>

--- a/app/views/doctors/_form.html.erb
+++ b/app/views/doctors/_form.html.erb
@@ -1,19 +1,37 @@
-<%= form_for @doctor, html: {class: "ui form"} do |f| %>
-  <div class="">
+<div class="ui raised segment container centered">
+  <%= form_for(@doctor, html: {class: "ui form"}) do |f| %>
+    
     <div class="field">
-      <%= f.label :name%>
+      <%= f.label :name %><br />
       <%= f.text_field :name %>
     </div>
-  </div>
-  
-  <div class="">
+
     <div class="field">
-      <%= f.label :email%>
-      <%= f.text_field :email %>
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
-  </div>
-  
-  <div class="button-group">
-    <%= f.submit "Submit", class: "ui button button-centered" %>
-  </div>
-<% end %>
+    
+    <div class="field">
+      <%= f.label :specialization %><br />
+      <%= f.collection_select(:specialization_id, Specialization.all, :id, :name, {}, { class: "ui dropdown" }) %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password %>
+      <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
+
+    <div class="button-group">
+      <%= f.submit "Sign up", class: "ui button button-centered" %>
+    </div>
+  <% end %>
+ 
+</div>

--- a/app/views/doctors/edit.html.erb
+++ b/app/views/doctors/edit.html.erb
@@ -1,4 +1,24 @@
-<div class="centered">
-  <h1>Edit Dr <%= @doctor.name %></h1>
-  <%= render "form" %>
+<div class="update-password">
+  <div id="edit-doctor">
+    <h1>Update your password</h1>
+    <div class="ui raised segment container centered" id="edit-doctor-form">
+      <%= form_for(@doctor, :url => { :action => "update_password" }, html: { class: "ui form" } ) do |f| %>
+        <div class="field">
+          <%= f.label :current_password %> <i>(Enter your current password to confirm your changes)</i><br />
+          <%= f.password_field :current_password %>
+        </div>
+        <div class="field">
+          <%= f.label :password, "New Password" %><br />
+          <%= f.password_field :password, :autocomplete => "off"  %>
+        </div>
+        <div class="field">
+          <%= f.label :password_confirmation, "Confirm your new password" %><br />
+          <%= f.password_field :password_confirmation %>
+        </div>
+        <div class="button-group">
+          <%= f.submit "Update Password", class: "ui button button-centered" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/doctors/new.html.erb
+++ b/app/views/doctors/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container centered">
-  <h1>Add a doctor</h1>
+<div class="container centered" id="new-doctor">
+  <h1 id="new-doctor-heading">Add a doctor</h1>
   <%= render "form" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get 'home/index'
-  devise_for :doctors
+  devise_for :doctors, path_prefix: 'admin'
   devise_for :patients
   get 'patients/new'
   get 'patients/edit'
@@ -16,8 +16,13 @@ Rails.application.routes.draw do
   resources :patients do
     get 'appointments', on: :member
   end
-  resources :doctors do
+  resources :doctors, except: :edit do
     get 'appointments', on: :member
+  end
+  resource :doctor, only: [:edit] do
+    collection do
+      patch 'update_password'
+    end
   end
   root 'home#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/helpers/doctors_helper_spec.rb
+++ b/spec/helpers/doctors_helper_spec.rb
@@ -11,5 +11,22 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe DoctorsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:appointment) { create :appointment }
+  context 'when a doctor checks if they have appointments' do
+    it 'returns true if he/she has' do
+      doctor = appointment.doctor
+      expect(doctor_has_appointments?(doctor)).to eq true
+      expect(doctor_has_appointments?(doctor)).to_not eq false
+    end
+  end
+
+  context 'when a doctor\'s appointments are reassigned' do
+    let!(:appointment) { create :appointment }
+    let!(:doctor) { create :doctor_with_specialization, admin: true }
+    it 'should remove all appointments from the doctor' do
+      doctor = appointment.doctor
+      reassign_appointments(doctor)
+      expect(doctor.appointments.count).to eq 0
+    end
+  end
 end

--- a/spec/mailers/doctor_mailer_spec.rb
+++ b/spec/mailers/doctor_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe DoctorMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -11,4 +11,9 @@ class AppointmentMailerPreview < ActionMailer::Preview
   def decline_appointment
     AppointmentMailer.with(appointment: Appointment.last).decline_appointment
   end
+
+  def change_of_doctor
+    AppointmentMailer.with(patient: Patient.last).change_of_doctor
+  end
+
 end

--- a/spec/mailers/previews/doctor_mailer_preview.rb
+++ b/spec/mailers/previews/doctor_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/doctor_mailer
+class DoctorMailerPreview < ActionMailer::Preview
+  def update_password
+    DoctorMailer.with(doctor: Doctor.last).update_password
+  end
+
+end


### PR DESCRIPTION
#### What does this PR do?
Allows admins add and delete doctors
#### Description of Task to be completed?
* Allow admins add new doctors to the system
* Allow admins delete doctors from the system
* Transition a doctor's appointments to pending when deleting them 
#### How should this be manually tested?
* Log in as an admin
* Click on the `Doctors` dropdown
* Click on the `Add a new doctor` option
* Fill in the details of the doctor you want to add and click Submit
* You should be redirected to the `Doctors` page and see the doctor you just added
* To delete a doctor while on the doctors' page, click on the `ellipsis` icon on a doctor's card
* Click on the `Delete` icon and confirm your decision
* You should no longer see the doctor you just deleted on the doctor's page
#### What are the relevant pivotal tracker stories?
[#161816973](https://www.pivotaltracker.com/story/show/161816973)
#### Any background context you want to add?
Doctors should only be added to the systems by admins
#### Screenshots
N/A